### PR TITLE
本地目录过滤

### DIFF
--- a/src/wisemodel_hub/__init__.py
+++ b/src/wisemodel_hub/__init__.py
@@ -5,7 +5,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "v0.5.0"
+__version__ = "v0.5.1"
 
 # 配置日志记录
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/src/wisemodel_hub/uploader.py
+++ b/src/wisemodel_hub/uploader.py
@@ -267,6 +267,8 @@ def push_to_hub(
     def upload_wrapper(args):
         rel_path, full_path = args[0], args[1]
         return upload_file(full_path, repo_id, repo_type, branch, commit_message, chunk_size, retries, timeout, repo_dir=os.path.dirname(rel_path))
+    # 去掉非法的文件路径
+    files_to_upload = [item for item in files_to_upload if item and len(item) == 2 and item[0] and item[1]]
     for rel_path, full_path in files_to_upload:
         # upload_file(full_path, repo_id, repo_type, branch, commit_message, chunk_size, retries, timeout, repo_dir=os.path.dirname(rel_path))
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:


### PR DESCRIPTION
在采集本地需要上传的文件时，可能创建空文件对象，将其过滤掉